### PR TITLE
fix copy command to work with mutiple source files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ install: $(LIB) $(INC) $(MAN)
 	mkdir -p $(DESTDIR)$(PREFIX)/lib
 	cp $(LIB) $(DESTDIR)$(PREFIX)/lib/$(LIB)
 	mkdir -p $(DESTDIR)$(PREFIX)/include
-	cp $(INC) $(DESTDIR)$(PREFIX)/include/$(INC)
+	cp -t $(DESTDIR)$(PREFIX)/include $(INC)
 	mkdir -p $(DESTDIR)$(PREFIX)/share/man/man3
 	cp $(MAN) $(DESTDIR)$(PREFIX)/share/man/man3/$(MAN)
 


### PR DESCRIPTION
Ran into a simple bug when trying to use this lib.

In `Makefile:26` `cp $(INC) $(DESTDIR)$(PREFIX)/include/$(INC)` resolve to `cp linenoise.h utf8.h /usr/local/include/linenoise.h utf8.h` in my case. Obviously, `cp` makes a big mess of that and fails.

The fix is simply to specify the target dir via `cp -t` and then slap all the source files at the end of the line.

Cheers,

Jesko