### PR TITLE
Don't free history atexit

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -1317,6 +1317,7 @@ void linenoiseFree(void *ptr) {
 
 /* ================================ History ================================= */
 
+#ifdef VALGRIND
 /* Free the history, but does not reset it. Only used when we have to
  * exit() to avoid memory leaks are reported by valgrind & co. */
 static void freeHistory(void) {
@@ -1328,11 +1329,14 @@ static void freeHistory(void) {
         free(history);
     }
 }
+#endif
 
 /* At exit we'll try to fix the terminal to the initial conditions. */
 static void linenoiseAtExit(void) {
     disableRawMode(STDIN_FILENO);
+#ifdef VALGRIND
     freeHistory();
+#endif
 }
 
 /* This is the API call to add a new entry in the linenoise history.


### PR DESCRIPTION
The memory allocated for the history entries will be automatically freed
by the operating system on program termination. Manually freeing it in
an atexit(3) handler prevents the caller from using it in his/her atexit
handler.

I noticed this because I call linenoiseHistorySave() in my atexit
handler which doesn't work without this change.

**Discussion:** I do understand that this is useful for debugging
memory leaks with valgrind but imho this needs to be disabled
by default. An alternative solution would be uncommenting
the function call in the atexit handler or only enabling it when
`-DVALGRIND` is set.