### PR TITLE
[WIP] Add support for completing words instead of lines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PREFIX = /usr/local
 CC = cc
-CFLAGS = -Os -Wall -Wextra
+CFLAGS = -Os -Wall -Wextra -D_GNU_SOURCE
 
 SRC = linenoise.c utf8.c
 OBJ = $(SRC:.c=.o)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PREFIX = /usr/local
 CC = cc
-CFLAGS = -Os -Wall -Wextra -D_GNU_SOURCE
+CFLAGS = -Os -Wall -Wextra
 
 SRC = linenoise.c utf8.c
 OBJ = $(SRC:.c=.o)

--- a/example.c
+++ b/example.c
@@ -10,8 +10,10 @@
 #include "utf8.h"
 #endif
 
+static linenoiseCompletionType comptype = LINENOISE_LINE;
+
 void completion(const char *buf, linenoiseCompletions *lc) {
-    if (buf[0] == 'h') {
+    if (comptype == LINENOISE_LINE && buf[0] == 'h') {
 #ifdef UTF8
         linenoiseAddCompletion(lc,"hello こんにちは");
         linenoiseAddCompletion(lc,"hello こんにちは there");
@@ -19,6 +21,14 @@ void completion(const char *buf, linenoiseCompletions *lc) {
         linenoiseAddCompletion(lc,"hello");
         linenoiseAddCompletion(lc,"hello there");
 #endif
+    }
+
+    if (comptype == LINENOISE_WORD) {
+        if (buf[0] == 'h') {
+            linenoiseAddCompletion(lc,"hello");
+        } else if (buf[0] == 't') {
+            linenoiseAddCompletion(lc,"there");
+        }
     }
 }
 
@@ -52,11 +62,14 @@ int main(int argc, char **argv) {
         if (!strcmp(*argv,"--multiline")) {
             linenoiseSetMultiLine(1);
             printf("Multi-line mode enabled.\n");
+        } else if (!strcmp(*argv,"--compwords")) {
+            comptype = LINENOISE_WORD;
+            printf("Completing words instead of lines.\n");
         } else if (!strcmp(*argv,"--keycodes")) {
             linenoisePrintKeyCodes();
             exit(0);
         } else {
-            fprintf(stderr, "Usage: %s [--multiline] [--keycodes]\n", prgname);
+            fprintf(stderr, "Usage: %s [--multiline] [--compwords] [--keycodes]\n", prgname);
             exit(1);
         }
     }
@@ -70,7 +83,7 @@ int main(int argc, char **argv) {
 
     /* Set the completion callback. This will be called every time the
      * user uses the <tab> key. */
-    linenoiseSetCompletionCallback(completion);
+    linenoiseSetCompletionCallback(completion, comptype);
     linenoiseSetHintsCallback(hints);
 
     /* Load history from file. The history file is just a plain text file

--- a/linenoise.c
+++ b/linenoise.c
@@ -443,12 +443,13 @@ static void linenoiseBeep(void) {
  * is inclusive, the end index is exclusive. The word length is
  * returned. */
 static size_t getCurrentWord(struct linenoiseState *ls, size_t *start, size_t *end) {
+    ssize_t n;
     char const *ws, *we;
 
-    if ((ws = memrchr(ls->buf, ' ', ls->pos)) == NULL)
-        ws = ls->buf;
-    else
-        ws++; /* within ls->buf but might be a nullbyte */
+    n = ls->pos;
+    while (n-- && ls->buf[n] != ' ') ;
+    ws = (n >= 0) ? &ls->buf[++n] : ls->buf;
+
     if ((we = strchr(ws, ' ')) == NULL)
         we = &ls->buf[strlen(ls->buf)]; /* nullbyte */
 

--- a/linenoise.h
+++ b/linenoise.h
@@ -51,10 +51,15 @@ typedef struct linenoiseCompletions {
   char **cvec;
 } linenoiseCompletions;
 
+typedef enum {
+    LINENOISE_LINE,
+    LINENOISE_WORD,
+} linenoiseCompletionType;
+
 typedef void(linenoiseCompletionCallback)(const char *, linenoiseCompletions *);
 typedef char*(linenoiseHintsCallback)(const char *, int *color, int *bold);
 typedef void(linenoiseFreeHintsCallback)(void *);
-void linenoiseSetCompletionCallback(linenoiseCompletionCallback *);
+void linenoiseSetCompletionCallback(linenoiseCompletionCallback *, linenoiseCompletionType);
 void linenoiseSetHintsCallback(linenoiseHintsCallback *);
 void linenoiseSetFreeHintsCallback(linenoiseFreeHintsCallback *);
 void linenoiseAddCompletion(linenoiseCompletions *, const char *);


### PR DESCRIPTION
I personally need to complete words, not entire lines and quickly hacked something together in order to figure out how easy it is to implement this in linenoise. This isn't finished yet but it works okish and I just wanted to hear your thoughts on this. The code is a bit ugly since string handling with C is somewhat tricky and the changes include an API change.

Demo:

[![asciicast](https://asciinema.org/a/j4dMGniAShnPZEMBS5NJ6dYye.svg)](https://asciinema.org/a/j4dMGniAShnPZEMBS5NJ6dYye)

I tried to make the changes as less intrusive as possible. This was achieved by only passing the current word to the completion callback and expanding all returned completions afterwards. This obviously isn't the most effective way to implement this (from a memory usage perspective) but it required only few changes to existing functions.

Limitations: Doesn't work with completions containing spaces.

TODO:

* [x] Remove dependency on memrchr (which is a GNU extension)
* [ ] Doesn't work properly if completion length < original line length
* [ ] Test it more extensively
* [ ] Fix all the bugs