### PR TITLE
Implementing forward\backward a word thorugh ctrl-<arrow>

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -1111,11 +1111,12 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
                                 linenoiseEditDelete(&l);
                                 break;
                             }
-                        }else if(seq[2] == ';'){
-													if (read(l.ifd,seq,2) == -1) break;
-													if (seq[0] == '5' && seq[1] == 'C') linenoiseEditMoveWordEnd(&l);
-													if (seq[0] == '5' && seq[1] == 'D') linenoiseEditMoveWordStart(&l);
-												}
+                        }
+			else if(seq[2] == ';') {
+				if (read(l.ifd,seq,2) == -1) break;
+				if (seq[0] == '5' && seq[1] == 'C') linenoiseEditMoveWordEnd(&l);
+				if (seq[0] == '5' && seq[1] == 'D') linenoiseEditMoveWordStart(&l);
+			}
                     } else {
                         switch(seq[1]) {
                         case 'A': /* Up */

--- a/linenoise.c
+++ b/linenoise.c
@@ -1111,7 +1111,11 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
                                 linenoiseEditDelete(&l);
                                 break;
                             }
-                        }
+                        }else if(seq[2] == ';'){
+													if (read(l.ifd,seq,2) == -1) break;
+													if (seq[0] == '5' && seq[1] == 'C') linenoiseEditMoveWordEnd(&l);
+													if (seq[0] == '5' && seq[1] == 'D') linenoiseEditMoveWordStart(&l);
+												}
                     } else {
                         switch(seq[1]) {
                         case 'A': /* Up */


### PR DESCRIPTION
The functions for jumping a word forward\backward were already there. I just added the functionality for them to be called with <kbd>Ctrl-left-arrow</kbd> and <kbd>Ctrl-right-arrow</kbd>. This is standard in [GNU readline](https://tiswww.case.edu/php/chet/readline/rltop.html) and I kinda can't live without it.